### PR TITLE
HOTFIX: WP_Widget is deprecated

### DIFF
--- a/microkids-related-posts-widget.php
+++ b/microkids-related-posts-widget.php
@@ -6,7 +6,7 @@ class WP_Widget_Related_Posts extends WP_Widget {
      */
 	function WP_Widget_Related_Posts() {
 		$widget_ops = array('classname' => 'widget_related_posts', 'description' => __( 'Display related posts as a widget', 'microkids-related-posts' ) );
-		$this->WP_Widget('related_posts', __('Related Posts', 'microkids-related-posts'), $widget_ops);
+		parent::__construct('related_posts', __('Related Posts', 'microkids-related-posts'), $widget_ops);
 	}
 	
 	/**


### PR DESCRIPTION
WP_Widget method is deprecated in Wordpress 4.3

If errors are being displayed, Line 9 of `microkids-related-posts-widget.php` will throw one, preventing headers from being set.

Error message:

> Notice: The called constructor method for WP_Widget is deprecated since version 4.3.0! Use __construct()
